### PR TITLE
Fix hardcoded white background on text areas.

### DIFF
--- a/NetbeansRegexPlugin/pom.xml
+++ b/NetbeansRegexPlugin/pom.xml
@@ -18,14 +18,14 @@
   </scm>
 
   <properties>
-    <netbeans.version>RELEASE82</netbeans.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <netbeans.version>RELEASE81</netbeans.version>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
 
   <build>
     <plugins>
-
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>nbm-maven-plugin</artifactId>
@@ -39,7 +39,6 @@
           <useOSGiDependencies>false</useOSGiDependencies>
         </configuration>
       </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
@@ -48,7 +47,6 @@
           <useDefaultManifestFile>true</useDefaultManifestFile>
         </configuration>
       </plugin>
-      
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
@@ -60,27 +58,10 @@
           </execution>
         </executions>
       </plugin>
-
       <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.6.201602180812</version>
-
-        <executions>
-          <execution>
-            <id>jacoco-initialize</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>jacoco-site</id>
-            <phase>package</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.20</version>
       </plugin>
     </plugins>
   </build>
@@ -96,25 +77,21 @@
       <groupId>org.netbeans.api</groupId>
       <artifactId>org-netbeans-modules-settings</artifactId>
       <version>${netbeans.version}</version>
-      <type>jar</type>
     </dependency>
     <dependency>
       <groupId>org.netbeans.api</groupId>
       <artifactId>org-openide-awt</artifactId>
       <version>${netbeans.version}</version>
-      <type>jar</type>
     </dependency>
     <dependency>
       <groupId>org.netbeans.api</groupId>
       <artifactId>org-openide-util</artifactId>
       <version>${netbeans.version}</version>
-      <type>jar</type>
     </dependency>
     <dependency>
       <groupId>org.netbeans.api</groupId>
       <artifactId>org-openide-windows</artifactId>
       <version>${netbeans.version}</version>
-      <type>jar</type>
     </dependency>
   </dependencies>
   

--- a/NetbeansRegexPlugin/src/main/java/de/dev/eth0/netbeans/plugins/regex/ui/UiTopComponent.form
+++ b/NetbeansRegexPlugin/src/main/java/de/dev/eth0/netbeans/plugins/regex/ui/UiTopComponent.form
@@ -151,11 +151,6 @@
                   </Properties>
                 </Component>
                 <Component class="javax.swing.JTextField" name="regularExpressionTextField">
-                  <Properties>
-                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-                      <ResourceString bundle="de/dev/eth0/netbeans/plugins/regex/ui/Bundle.properties" key="UiTopComponent.regularExpressionTextField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-                    </Property>
-                  </Properties>
                 </Component>
                 <Component class="javax.swing.JLabel" name="jLabel2">
                   <Properties>
@@ -165,11 +160,6 @@
                   </Properties>
                 </Component>
                 <Component class="javax.swing.JTextField" name="replacementTextField">
-                  <Properties>
-                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-                      <ResourceString bundle="de/dev/eth0/netbeans/plugins/regex/ui/Bundle.properties" key="UiTopComponent.replacementTextField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-                    </Property>
-                  </Properties>
                 </Component>
                 <Component class="javax.swing.JLabel" name="jLabel5">
                   <Properties>
@@ -203,15 +193,11 @@
                     <Component class="javax.swing.JTextArea" name="hintTextArea">
                       <Properties>
                         <Property name="editable" type="boolean" value="false"/>
-                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
-                          <Color blue="f0" green="f0" red="f0" type="rgb"/>
-                        </Property>
                         <Property name="columns" type="int" value="20"/>
                         <Property name="rows" type="int" value="5"/>
                         <Property name="disabledTextColor" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
                           <Color blue="0" green="0" red="0" type="rgb"/>
                         </Property>
-                        <Property name="enabled" type="boolean" value="false"/>
                       </Properties>
                     </Component>
                   </SubComponents>
@@ -363,15 +349,11 @@
                     <Component class="javax.swing.JTextArea" name="groupsTextArea">
                       <Properties>
                         <Property name="editable" type="boolean" value="false"/>
-                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
-                          <Color blue="f0" green="f0" red="f0" type="rgb"/>
-                        </Property>
                         <Property name="columns" type="int" value="20"/>
                         <Property name="rows" type="int" value="5"/>
                         <Property name="disabledTextColor" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
                           <Color blue="0" green="0" red="0" type="rgb"/>
                         </Property>
-                        <Property name="enabled" type="boolean" value="false"/>
                       </Properties>
                     </Component>
                   </SubComponents>

--- a/NetbeansRegexPlugin/src/main/java/de/dev/eth0/netbeans/plugins/regex/ui/UiTopComponent.java
+++ b/NetbeansRegexPlugin/src/main/java/de/dev/eth0/netbeans/plugins/regex/ui/UiTopComponent.java
@@ -19,18 +19,21 @@
  */
 package de.dev.eth0.netbeans.plugins.regex.ui;
 
-import de.dev.eth0.netbeans.plugins.regex.RegexEvaluator;
-import de.dev.eth0.netbeans.plugins.regex.RegexEvaluator.MatcherGroup;
 import java.awt.Color;
 import java.util.regex.Pattern;
+
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+
 import org.netbeans.api.settings.ConvertAsProperties;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.util.NbBundle;
 import org.openide.util.NbBundle.Messages;
 import org.openide.windows.TopComponent;
+
+import de.dev.eth0.netbeans.plugins.regex.RegexEvaluator;
+import de.dev.eth0.netbeans.plugins.regex.RegexEvaluator.MatcherGroup;
 
 /**
  * Top component which displays something.
@@ -60,6 +63,8 @@ import org.openide.windows.TopComponent;
 })
 public final class UiTopComponent extends TopComponent {
 
+  private final  Color TXF_DEFAULT;
+  private final Color TXF_ERROR;
   private final RegexEvaluator evaluator;
 
   public UiTopComponent() {
@@ -67,6 +72,8 @@ public final class UiTopComponent extends TopComponent {
     setName(Bundle.CTL_UiTopComponent());
     setToolTipText(Bundle.HINT_UiTopComponent());
     evaluator = new RegexEvaluator();
+    TXF_DEFAULT=regularExpressionTextField.getForeground();
+    TXF_ERROR=Color.red;
   }
 
   /**
@@ -126,11 +133,7 @@ public final class UiTopComponent extends TopComponent {
 
     org.openide.awt.Mnemonics.setLocalizedText(jLabel1, org.openide.util.NbBundle.getMessage(UiTopComponent.class, "UiTopComponent.jLabel1.text")); // NOI18N
 
-    regularExpressionTextField.setText(org.openide.util.NbBundle.getMessage(UiTopComponent.class, "UiTopComponent.regularExpressionTextField.text")); // NOI18N
-
     org.openide.awt.Mnemonics.setLocalizedText(jLabel2, org.openide.util.NbBundle.getMessage(UiTopComponent.class, "UiTopComponent.jLabel2.text")); // NOI18N
-
-    replacementTextField.setText(org.openide.util.NbBundle.getMessage(UiTopComponent.class, "UiTopComponent.replacementTextField.text")); // NOI18N
 
     org.openide.awt.Mnemonics.setLocalizedText(jLabel5, org.openide.util.NbBundle.getMessage(UiTopComponent.class, "UiTopComponent.jLabel5.text")); // NOI18N
 
@@ -139,11 +142,9 @@ public final class UiTopComponent extends TopComponent {
     jScrollPane1.setViewportView(input1TextArea);
 
     hintTextArea.setEditable(false);
-    hintTextArea.setBackground(new java.awt.Color(240, 240, 240));
     hintTextArea.setColumns(20);
     hintTextArea.setRows(5);
     hintTextArea.setDisabledTextColor(new java.awt.Color(0, 0, 0));
-    hintTextArea.setEnabled(false);
     jScrollPane3.setViewportView(hintTextArea);
 
     javax.swing.GroupLayout jPanel3Layout = new javax.swing.GroupLayout(jPanel3);
@@ -206,11 +207,9 @@ public final class UiTopComponent extends TopComponent {
     org.openide.awt.Mnemonics.setLocalizedText(jLabel11, org.openide.util.NbBundle.getMessage(UiTopComponent.class, "UiTopComponent.jLabel11.text")); // NOI18N
 
     groupsTextArea.setEditable(false);
-    groupsTextArea.setBackground(new java.awt.Color(240, 240, 240));
     groupsTextArea.setColumns(20);
     groupsTextArea.setRows(5);
     groupsTextArea.setDisabledTextColor(new java.awt.Color(0, 0, 0));
-    groupsTextArea.setEnabled(false);
     jScrollPane2.setViewportView(groupsTextArea);
 
     jSeparator1.setOrientation(javax.swing.SwingConstants.VERTICAL);
@@ -553,11 +552,11 @@ public final class UiTopComponent extends TopComponent {
     evaluator.update(regex, getFlags(), replacement, input);
 
     if (evaluator.valid) {
-      regularExpressionTextField.setForeground(Color.black);
+      regularExpressionTextField.setForeground(TXF_DEFAULT);
       hintTextArea.setText("");
     }
     else {
-      regularExpressionTextField.setForeground(Color.red);
+      regularExpressionTextField.setForeground(TXF_ERROR);
       hintTextArea.setText(evaluator.invalidReason);
     }
     matchesLabel.setText(NbBundle.getMessage(UiTopComponent.class, evaluator.matches ? "UiTopComponent.true" : "UiTopComponent.false"));

--- a/NetbeansRegexPlugin/src/main/resources/de/dev/eth0/netbeans/plugins/regex/ui/Bundle.properties
+++ b/NetbeansRegexPlugin/src/main/resources/de/dev/eth0/netbeans/plugins/regex/ui/Bundle.properties
@@ -1,10 +1,8 @@
 UiTopComponent_menu=Regex Tester
 UiTopComponent.name=Regex Tester
 UiTopComponent.jLabel1.text=Regular Expression:
-UiTopComponent.regularExpressionTextField.text=
 UiTopComponent.jLabel2.text=Input:
 UiTopComponent.jLabel5.text=Replacement:
-UiTopComponent.replacementTextField.text=
 UiTopComponent.jLabel11.text=n [start(n),end(n)] group(n)
 UiTopComponent.jLabel10.text=find():
 UiTopComponent.jLabel9.text=lookingAt():


### PR DESCRIPTION
This makes the RegexTester window nicer when using dark LnFs like Darcula.

Also makes text areas enabled (but remain non editable) to avoid low contrast appearance on light LnFs.