### PR TITLE
Added a dependency to get the plugin going under jdk11 and Netbeans 12

### DIFF
--- a/NetbeansRegexPlugin/pom.xml
+++ b/NetbeansRegexPlugin/pom.xml
@@ -115,6 +115,12 @@
             <artifactId>org-netbeans-modules-options-api</artifactId>
             <version>${netbeans.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.netbeans.external</groupId>
+            <artifactId>javax.annotation-api-1.2</artifactId>
+            <version>RELEASE74-BETA</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
While searching for Netbeans module examples I found yours and fixed it for the current nb version along with an up to date Java version. 